### PR TITLE
Releasing sample label

### DIFF
--- a/publishPlateMapSetUp.js
+++ b/publishPlateMapSetUp.js
@@ -7,7 +7,6 @@ let lzutf8 = require("lzutf8");
 
 const http = process.env.KAPTURE_SERVER.startsWith('localhost')? 'http://' : 'https://';
 const url = http + process.env.KAPTURE_SERVER + '/api/external-integrations/atlas';
-//const url = "https://kapture-staging.apps.kaleidobio.com/api/external-integrations/atlas"
 const authenticate_url = 'https://kapture.apps.kaleidobio.com/api/authenticate';
 const username = process.env.KAPTURE_USERNAME;
 const password = process.env.KAPTURE_PASSWORD;


### PR DESCRIPTION
Checks to see if there is a barcode for the plate, then if there is uses the barcode for the sample label instead of the old formulation of G#.P#.well_id